### PR TITLE
Fix/#22 card 상세조회 수정

### DIFF
--- a/src/main/java/com/sparta/trello/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trello/card/controller/CardController.java
@@ -36,8 +36,8 @@ public class CardController {
   }
 
   @GetMapping("/cards/{cardId}")
-  public ResponseEntity<CardDetailsResponseDto> getCardDetailsById(@PathVariable Long cardId) {
-    CardDetailsResponseDto responseDto = cardService.getCardDetailsById(cardId);
+  public ResponseEntity<CardDetailsResponseDto> getCardDetailsById(@RequestParam int page, @RequestParam(defaultValue = "5") int amount, @PathVariable Long cardId) {
+    CardDetailsResponseDto responseDto = cardService.getCardDetailsById(page - 1, amount, cardId);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 

--- a/src/main/java/com/sparta/trello/card/controller/CardController.java
+++ b/src/main/java/com/sparta/trello/card/controller/CardController.java
@@ -1,6 +1,7 @@
 package com.sparta.trello.card.controller;
 
 import com.sparta.trello.card.dto.CardCreateRequestDto;
+import com.sparta.trello.card.dto.CardDetailsResponseDto;
 import com.sparta.trello.card.dto.CardResponseDto;
 import com.sparta.trello.card.dto.CardSearchCondDto;
 import com.sparta.trello.card.dto.CardUpdateCardStatusRequestDto;
@@ -35,8 +36,8 @@ public class CardController {
   }
 
   @GetMapping("/cards/{cardId}")
-  public ResponseEntity<CardResponseDto> getCardDetailsById(@PathVariable Long cardId) {
-    CardResponseDto responseDto = cardService.getCardDetailsById(cardId);
+  public ResponseEntity<CardDetailsResponseDto> getCardDetailsById(@PathVariable Long cardId) {
+    CardDetailsResponseDto responseDto = cardService.getCardDetailsById(cardId);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
@@ -52,16 +53,16 @@ public class CardController {
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
-  @PostMapping("/cards/{cardId}")
+  @PutMapping("/cards/{cardId}/status")
   public ResponseEntity<CardResponseDto> updateCardStatus(@PathVariable Long cardId, @RequestBody CardUpdateCardStatusRequestDto requestDto) {
     CardResponseDto responseDto = cardService.updateCardStatus(cardId, requestDto);
     return new ResponseEntity<>(responseDto, HttpStatus.OK);
   }
 
-  @PostMapping("/cards/{cardId}/position")
-  public ResponseEntity<CardResponseDto> updateCardStatus(@PathVariable Long cardId, @RequestParam int newPosition) {
-    CardResponseDto responseDto = cardService.moveCardToPosition(cardId, newPosition);
-    return new ResponseEntity<>(responseDto, HttpStatus.OK);
+  @PutMapping("/cards/{cardId}/position")
+  public ResponseEntity<String> moveCardToPosition(@PathVariable Long cardId, @RequestParam int newPosition) {
+    cardService.moveCardToPosition(cardId, newPosition - 1);
+    return new ResponseEntity<>("순서이동 성공",HttpStatus.OK);
   }
 
   @DeleteMapping("/cards/{id}")

--- a/src/main/java/com/sparta/trello/card/dto/CardDetailsResponseDto.java
+++ b/src/main/java/com/sparta/trello/card/dto/CardDetailsResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.trello.card.dto;
+
+import com.sparta.trello.card.entity.Card;
+import com.sparta.trello.columns.entity.CategoryEnum;
+import com.sparta.trello.comment.entity.Comment;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CardDetailsResponseDto {
+
+  private String title;
+  private String content;
+  private String dueDate;
+  private CategoryEnum cardStatus;
+  private List<Comment> commentList;
+//  private String username;
+
+  public CardDetailsResponseDto(Card card) {
+    this.title = card.getTitle();
+    this.content = card.getContent();
+    this.dueDate = card.getDueDate();
+    this.cardStatus = card.getCardStatus();
+    this.commentList = card.getComments();
+  }
+}

--- a/src/main/java/com/sparta/trello/card/dto/CardDetailsResponseDto.java
+++ b/src/main/java/com/sparta/trello/card/dto/CardDetailsResponseDto.java
@@ -2,6 +2,7 @@ package com.sparta.trello.card.dto;
 
 import com.sparta.trello.card.entity.Card;
 import com.sparta.trello.columns.entity.CategoryEnum;
+import com.sparta.trello.comment.dto.CommentResponseDto;
 import com.sparta.trello.comment.entity.Comment;
 import java.util.List;
 import lombok.Getter;
@@ -15,14 +16,14 @@ public class CardDetailsResponseDto {
   private String content;
   private String dueDate;
   private CategoryEnum cardStatus;
-  private List<Comment> commentList;
+  private List<CommentResponseDto> commentList;
 //  private String username;
 
-  public CardDetailsResponseDto(Card card) {
+  public CardDetailsResponseDto(Card card, List<CommentResponseDto> commentList) {
     this.title = card.getTitle();
     this.content = card.getContent();
     this.dueDate = card.getDueDate();
     this.cardStatus = card.getCardStatus();
-    this.commentList = card.getComments();
+    this.commentList = commentList;
   }
 }

--- a/src/main/java/com/sparta/trello/card/dto/CardResponseDto.java
+++ b/src/main/java/com/sparta/trello/card/dto/CardResponseDto.java
@@ -2,12 +2,16 @@ package com.sparta.trello.card.dto;
 
 import com.sparta.trello.card.entity.Card;
 import com.sparta.trello.columns.entity.CategoryEnum;
+import com.sparta.trello.comment.entity.Comment;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class CardResponseDto {
+
+  private int position;
   private String title;
   private String content;
   private String dueDate;
@@ -15,6 +19,7 @@ public class CardResponseDto {
 //  private String username;
 
   public CardResponseDto(Card card) {
+    this.position = card.getPosition();
     this.title = card.getTitle();
     this.content = card.getContent();
     this.dueDate = card.getDueDate();

--- a/src/main/java/com/sparta/trello/card/dto/CardSearchCondDto.java
+++ b/src/main/java/com/sparta/trello/card/dto/CardSearchCondDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CardSearchCondDto {
+
 //  private String username;
   private String cardStatus;
 

--- a/src/main/java/com/sparta/trello/card/entity/Card.java
+++ b/src/main/java/com/sparta/trello/card/entity/Card.java
@@ -39,7 +39,7 @@ public class Card extends Timestamped {
 
   private String title;
   private String content;
-  private Integer position;
+  private int position;
 
   @Column(name = "dueto_date")
   private String dueDate;
@@ -77,6 +77,10 @@ public class Card extends Timestamped {
   public void updateCardStatus(Columns column, CardUpdateCardStatusRequestDto requestDto) {
     this.columns = column;
     this.cardStatus = CategoryEnum.valueOf(requestDto.getCardStatus());
+  }
+
+  public void updatePosition(int newPosition) {
+    this.position = newPosition;
   }
 
 //  public boolean checkUser(User user) {

--- a/src/main/java/com/sparta/trello/card/repository/CardCustomRepository.java
+++ b/src/main/java/com/sparta/trello/card/repository/CardCustomRepository.java
@@ -2,9 +2,13 @@ package com.sparta.trello.card.repository;
 
 import com.sparta.trello.card.dto.CardResponseDto;
 import com.sparta.trello.card.dto.CardSearchCondDto;
+import com.sparta.trello.card.entity.Card;
 import java.util.List;
 
 public interface CardCustomRepository {
 
   List<CardResponseDto> findCardsInColumn(CardSearchCondDto searchCond);
+
+  List<Card> findByColumnIdOrderByPositionAsc(Long id);
+
 }

--- a/src/main/java/com/sparta/trello/card/repository/CardCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/trello/card/repository/CardCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.trello.card.dto.CardResponseDto;
 import com.sparta.trello.card.dto.CardSearchCondDto;
+import com.sparta.trello.card.entity.Card;
 import com.sparta.trello.card.entity.QCard;
 import com.sparta.trello.columns.entity.CategoryEnum;
 import com.sparta.trello.columns.entity.QColumns;
@@ -35,7 +36,19 @@ public class CardCustomRepositoryImpl implements CardCustomRepository{
     return cardList;
   }
 
-  private BooleanExpression isWhere (CardSearchCondDto searchCond){
+  public List<Card> findByColumnIdOrderByPositionAsc(Long id) {
+    QCard card = QCard.card;
+
+    List<Card> cards = queryFactory
+        .selectFrom(card)
+        .where(card.columns.id.eq(id))
+        .orderBy(card.position.asc())
+        .fetch();
+
+    return cards;
+  }
+
+  private BooleanExpression isWhere (CardSearchCondDto searchCond) {
     BooleanExpression result = null;
 //    if(!searchCond.getUsername().isEmpty()){
 //      return result = card.user.name.eq(searchCond.getUsername());

--- a/src/main/java/com/sparta/trello/card/service/CardService.java
+++ b/src/main/java/com/sparta/trello/card/service/CardService.java
@@ -10,8 +10,14 @@ import com.sparta.trello.card.entity.Card;
 import com.sparta.trello.card.repository.CardRepository;
 import com.sparta.trello.columns.entity.Columns;
 import com.sparta.trello.columns.services.ColumnsServices;
+import com.sparta.trello.comment.dto.CommentResponseDto;
+import com.sparta.trello.comment.entity.Comment;
+import com.sparta.trello.comment.repository.CommentRepository;
+import com.sparta.trello.comment.service.CommentService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,15 +27,18 @@ public class CardService {
 
   private final CardRepository cardRepository;
   private final ColumnsServices columnsServices;
+  private final CommentService commentService;
+  private final CommentRepository commentRepository;
 
   public List<CardResponseDto> getAllCards(CardSearchCondDto searchCond) {
     List<CardResponseDto> cardList = cardRepository.findCardsInColumn(searchCond);
     return cardList;
   }
 
-  public CardDetailsResponseDto getCardDetailsById(Long cardId) {
+  public CardDetailsResponseDto getCardDetailsById(int page, int amount, Long cardId) {
     Card card = findCardById(cardId);
-   return new CardDetailsResponseDto(card);
+    List<CommentResponseDto> commentDtos = commentRepository.findCommentByCardIdOrderByCreatedAtDesc(page, amount, cardId);
+   return new CardDetailsResponseDto(card, commentDtos);
   }
 
   @Transactional

--- a/src/main/java/com/sparta/trello/card/service/CardService.java
+++ b/src/main/java/com/sparta/trello/card/service/CardService.java
@@ -1,6 +1,7 @@
 package com.sparta.trello.card.service;
 
 import com.sparta.trello.card.dto.CardCreateRequestDto;
+import com.sparta.trello.card.dto.CardDetailsResponseDto;
 import com.sparta.trello.card.dto.CardResponseDto;
 import com.sparta.trello.card.dto.CardSearchCondDto;
 import com.sparta.trello.card.dto.CardUpdateCardStatusRequestDto;
@@ -8,7 +9,7 @@ import com.sparta.trello.card.dto.CardUpdateRequestDto;
 import com.sparta.trello.card.entity.Card;
 import com.sparta.trello.card.repository.CardRepository;
 import com.sparta.trello.columns.entity.Columns;
-import com.sparta.trello.columns.repository.ColumnsRepository;
+import com.sparta.trello.columns.services.ColumnsServices;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,22 +20,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class CardService {
 
   private final CardRepository cardRepository;
-  private final ColumnsRepository columnsRepository;
+  private final ColumnsServices columnsServices;
 
   public List<CardResponseDto> getAllCards(CardSearchCondDto searchCond) {
     List<CardResponseDto> cardList = cardRepository.findCardsInColumn(searchCond);
     return cardList;
   }
 
-  public CardResponseDto getCardDetailsById(Long cardId) {
+  public CardDetailsResponseDto getCardDetailsById(Long cardId) {
     Card card = findCardById(cardId);
-   return new CardResponseDto(card);
+   return new CardDetailsResponseDto(card);
   }
 
   @Transactional
   public CardResponseDto createCard(Long id, CardCreateRequestDto requestDto) {
-    Columns columns = findColumnById(id);
+    Columns columns = columnsServices.findById(id);
+    int position= getNextPosition(columns.getId());
     Card card = cardRepository.save(new Card(requestDto, columns));
+    card.setPosition(position);
     return new CardResponseDto(card);
   }
 
@@ -49,52 +52,76 @@ public class CardService {
   @Transactional
   public CardResponseDto updateCardStatus(Long cardId, CardUpdateCardStatusRequestDto requestDto) {
     Card card = findCardById(cardId);
-    Columns column = findColumnById(requestDto.getColumnId());
+    Columns column = columnsServices.findById(requestDto.getColumnId());
     card.updateCardStatus(column, requestDto);
     return new CardResponseDto(card);
   }
 
   @Transactional
-  public CardResponseDto moveCardToPosition(Long cardId, int newPosition) {
+  public void moveCardToPosition(Long cardId, int newPosition) {
     Card card = findCardById(cardId);
-    // 컬럼 구별 필요
-    List<Card> cards = cardRepository.findAll();
+    Columns column = card.getColumns();
+    int currentPosition = card.getPosition();
 
-    int currentPosition = cards.indexOf(card);
-    int changePosition = newPosition - 1;
+    List<Card> cards = cardRepository.findByColumnIdOrderByPositionAsc(column.getId());
 
     if (newPosition < 0 || newPosition >= cards.size()) {
       throw new IllegalArgumentException("잘못된 카드 위치번호 입니다.");
     }
 
-    if (currentPosition != newPosition) {
-      cards.remove(currentPosition);
-      cards.add(changePosition, card);
-      updateCardIndex(cards);
+    if(currentPosition < newPosition) {
+      for(Card c : cards) {
+        if (c.getPosition() > currentPosition && c.getPosition() <= newPosition) {
+          c.setPosition(c.getPosition() - 1);
+          cardRepository.save(c);
+        }
+      }
+    } else {
+      for(Card c : cards) {
+        if(c.getPosition() >= newPosition && c.getPosition() < currentPosition) {
+          c.setPosition(c.getPosition() + 1);
+          cardRepository.save(c);
+        }
+      }
     }
-    return new CardResponseDto(card);
+    updateCardPosition(cardId, newPosition);
+    reorderCards(column.getId());
   }
 
   @Transactional
-  public void deleteCard(Long id) {
-    Card card = findCardById(id);
+  public void deleteCard(Long cardId) {
+    Card card = findCardById(cardId);
 //    card.checkUser(user);
     cardRepository.delete(card);
   }
 
-   // 나중에 columns service에서 가져오기 수정필요**
-  private Columns findColumnById(Long id) {
-    return columnsRepository.findById(id).orElseThrow(
-        ()-> new IllegalArgumentException("해당 컬럼을 찾을 수 없습니다."));
+  private Card findCardById(Long cardId) {
+    return cardRepository.findCardById(cardId);
   }
 
-  private Card findCardById(Long id) {
-    return cardRepository.findCardById(id);
+  private int getNextPosition(Long id) {
+    List<Card> cards = cardRepository.findByColumnIdOrderByPositionAsc(id);
+    if (cards.isEmpty()) {
+      return 0;
+    }
+    return cards.get(cards.size() - 1).getPosition() + 1;
   }
 
-  private void updateCardIndex(List<Card> cards) {
-    for (int i=0; i < cards.size(); i++) {
-      cards.get(i).setPosition(i + 1);
+  private void reorderCards(Long id) {
+    List<Card> cards = cardRepository.findByColumnIdOrderByPositionAsc(id);
+    int position = 0;
+    for(Card card : cards) {
+      if (card.getPosition() != position) {
+        updateCardPosition(card.getId(), position);
+      }
+      position++;
     }
   }
+
+  private void updateCardPosition(Long cardId, int position) {
+    Card card = cardRepository.findCardById(cardId);
+    card.updatePosition(position);
+    cardRepository.save(card);
+  }
+
 }


### PR DESCRIPTION
## 📌 What is this PR ?

카드 상세조회 및 순서이동 기능 수정

<br/>

## 🔎 Additions / Changes
Additions

card 상세조회시 댓글리스트 함께 조회(댓글리스트 페이지처리 amount =5)
card 순서이동 드래그앤드롭 기능 가능하도록 구현해보았으나 프론트에서 어떻게 적용할지 모르겠습니다. 

<br/>

## 📷 Screenshot
해당 코드가 잘 실행되는 스크린샷을 남겨주세요

| 기능 | 스크린샷 |
| --- | --- |
| 순서이동 | ![image](https://github.com/user-attachments/assets/69b4b774-411f-4de4-b959-e7eb294dc4bd) |
| 순서이동 전 DB | ![image](https://github.com/user-attachments/assets/5756f884-2152-4dc0-ade0-f7d563b08c69) |
| 순서이동 후 DB | ![image](https://github.com/user-attachments/assets/8636d3c7-bcc4-4db8-8136-d4a43c43b383) |
| 카드 상세조회(댓글 페이지처리 amount = 5) | ![image](https://github.com/user-attachments/assets/2a08c284-cfaf-4e44-9c70-431db8fd4aa9) |

<br/>


