### PR TITLE
Fix/#23 auth 예외처리 공통설정 및 주석, 컨벤션 수정

### DIFF
--- a/src/main/java/com/sparta/trello/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/trello/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.sparta.trello.auth.dto.TokenResponseDto;
 import com.sparta.trello.auth.security.UserDetailsImpl;
 import com.sparta.trello.auth.service.AuthService;
 import com.sparta.trello.common.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -90,12 +91,12 @@ public class AuthController {
     /**
      * 토큰 재발급 API
      *
-     * @param refreshToken 헤더에 존재하는 refreshToken
+     * @param request HTTP 요청 정보
      * @return 재발급된 토큰 응답 데이터
      */
     @PostMapping("/refresh-token")
-    public ResponseEntity<ApiResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
-        TokenResponseDto responseDto = authService.refreshToken(refreshToken);
+    public ResponseEntity<ApiResponse> refreshToken(HttpServletRequest request) {
+        TokenResponseDto responseDto = authService.refreshToken(request);
         ApiResponse response = ApiResponse.builder()
                 .msg("토큰 재발급 성공")
                 .statuscode(String.valueOf(HttpStatus.OK.value()))

--- a/src/main/java/com/sparta/trello/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/trello/auth/controller/AuthController.java
@@ -12,10 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -86,6 +83,23 @@ public class AuthController {
         ApiResponse response = ApiResponse.builder()
                 .msg("회원탈퇴 성공")
                 .statuscode(String.valueOf(HttpStatus.NO_CONTENT.value()))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * 토큰 재발급 API
+     *
+     * @param refreshToken 헤더에 존재하는 refreshToken
+     * @return 재발급된 토큰 응답 데이터
+     */
+    @PostMapping("/refresh-token")
+    public ResponseEntity<ApiResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        TokenResponseDto responseDto = authService.refreshToken(refreshToken);
+        ApiResponse response = ApiResponse.builder()
+                .msg("토큰 재발급 성공")
+                .statuscode(String.valueOf(HttpStatus.OK.value()))
+                .data(responseDto)
                 .build();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/sparta/trello/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/trello/auth/controller/AuthController.java
@@ -1,9 +1,9 @@
 package com.sparta.trello.auth.controller;
 
 import com.sparta.trello.auth.dto.LoginRequestDto;
-import com.sparta.trello.auth.dto.LoginResponseDto;
 import com.sparta.trello.auth.dto.SignupRequestDto;
 import com.sparta.trello.auth.dto.SignupResponseDto;
+import com.sparta.trello.auth.dto.TokenResponseDto;
 import com.sparta.trello.auth.security.UserDetailsImpl;
 import com.sparta.trello.auth.service.AuthService;
 import com.sparta.trello.common.ApiResponse;
@@ -24,7 +24,12 @@ public class AuthController {
 
     private final AuthService authService;
 
-    // 회원가입 API
+    /**
+     * 회원가입 API
+     *
+     * @param requestDto 회원가입 요청 데이터
+     * @return 회원가입 응답 데이터
+     */
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse> signup(@Valid @RequestBody SignupRequestDto requestDto) {
         SignupResponseDto responseDto = authService.signup(requestDto);
@@ -36,10 +41,15 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // 로그인 API
+    /**
+     * 로그인 API
+     *
+     * @param requestDto 로그인 요청 데이터
+     * @return 발급된 토큰 응답 데이터
+     */
     @PostMapping("/login")
     public ResponseEntity<ApiResponse> login(@Valid @RequestBody LoginRequestDto requestDto) {
-        LoginResponseDto responseDto = authService.login(requestDto);
+        TokenResponseDto responseDto = authService.login(requestDto);
         ApiResponse response = ApiResponse.builder()
                 .msg("로그인 성공")
                 .statuscode(String.valueOf(HttpStatus.OK.value()))
@@ -48,7 +58,12 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    // 로그아웃 API
+    /**
+     * 로그아웃 API
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @return 로그아웃 성공 응답
+     */
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         authService.logout(userDetails.getUser());
@@ -59,7 +74,12 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    // 회원탈퇴 API
+    /**
+     * 회원탈퇴 API
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @return 회원탈퇴 성공 응답
+     */
     @PostMapping("/withdraw")
     public ResponseEntity<ApiResponse> withdraw(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         authService.withdraw(userDetails.getUser());

--- a/src/main/java/com/sparta/trello/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/sparta/trello/auth/dto/LoginRequestDto.java
@@ -1,9 +1,17 @@
 package com.sparta.trello.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
 public class LoginRequestDto {
+    @NotBlank(message = "사용자 ID는 필수 입력 사항입니다.")
+    @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "사용자 ID는 알파벳 소문자와 숫자로 이루어진 4자에서 10자 사이여야 합니다.")
     private String username;
+
+    @NotBlank(message = "비밀번호는 필수 입력 사항입니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+            message = "최소 8자 이상, 15자 이하이며 알파벳 대소문자(az, AZ), 숫자(0~9),특수문자로 구성되어야 합니다.")
     private String password;
 }

--- a/src/main/java/com/sparta/trello/auth/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/trello/auth/dto/SignupRequestDto.java
@@ -2,17 +2,23 @@ package com.sparta.trello.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignupRequestDto {
     @NotBlank(message = "사용자 ID는 필수 입력 사항입니다.")
-    @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "사용자 ID는 알파벳 소문자와 숫자로 이루어진 4자에서 10자 사이여야 합니다.")
+    @Pattern(regexp = "^[a-z0-9]{4,10}$",
+            message = "아이디는 최소 4자 이상, 10자 이하이며 알파벳 소문자(a~z), 숫자(0~9)로 구성되어야 합니다.")
     private String username;
 
     @NotBlank(message = "비밀번호는 필수 입력 사항입니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+            message = "최소 8자 이상, 15자 이하이며 알파벳 대소문자(az, AZ), 숫자(0~9),특수문자로 구성되어야 합니다.")
     private String password;
 
     @NotBlank(message = "이름은 필수 입력 사항입니다.")

--- a/src/main/java/com/sparta/trello/auth/dto/SignupResponseDto.java
+++ b/src/main/java/com/sparta/trello/auth/dto/SignupResponseDto.java
@@ -1,6 +1,7 @@
 package com.sparta.trello.auth.dto;
 
 import com.sparta.trello.auth.entity.User;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -8,6 +9,7 @@ public class SignupResponseDto {
     private String username;
     private String name;
 
+    @Builder
     public SignupResponseDto(User user) {
         this.username = user.getUsername();
         this.name = user.getName();

--- a/src/main/java/com/sparta/trello/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/sparta/trello/auth/dto/TokenResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class LoginResponseDto {
+public class TokenResponseDto {
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/com/sparta/trello/auth/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/trello/auth/security/UserDetailsServiceImpl.java
@@ -2,8 +2,9 @@ package com.sparta.trello.auth.security;
 
 import com.sparta.trello.auth.entity.User;
 import com.sparta.trello.auth.repository.UserRepository;
+import com.sparta.trello.common.exception.CustomException;
+import com.sparta.trello.common.exception.ErrorEnum;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -18,7 +19,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new CustomException(ErrorEnum.USER_NOT_FOUND));
 
         return new UserDetailsImpl(user);
     }

--- a/src/main/java/com/sparta/trello/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/trello/auth/service/AuthService.java
@@ -1,13 +1,15 @@
 package com.sparta.trello.auth.service;
 
 import com.sparta.trello.auth.dto.LoginRequestDto;
-import com.sparta.trello.auth.dto.LoginResponseDto;
 import com.sparta.trello.auth.dto.SignupRequestDto;
 import com.sparta.trello.auth.dto.SignupResponseDto;
+import com.sparta.trello.auth.dto.TokenResponseDto;
 import com.sparta.trello.auth.entity.Role;
 import com.sparta.trello.auth.entity.User;
 import com.sparta.trello.auth.entity.UserStatus;
 import com.sparta.trello.auth.repository.UserRepository;
+import com.sparta.trello.common.exception.CustomException;
+import com.sparta.trello.common.exception.ErrorEnum;
 import com.sparta.trello.common.jwt.JwtUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -28,21 +30,27 @@ public class AuthService {
     @Value("${manager.token.key}")
     private String MANAGER_TOKEN;
 
-    // 회원가입
+    /**
+     * 회원가입
+     *
+     * @param requestDto 회원가입 요청 데이터
+     * @return 회원가입 응답 데이터
+     */
     public SignupResponseDto signup(SignupRequestDto requestDto) {
         String username = requestDto.getUsername();
         String password = passwordEncoder.encode(requestDto.getPassword());
 
         Optional<User> checkUser = userRepository.findByUsername(username);
+        // 중복 사용자 확인
         if (checkUser.isPresent()) {
-            throw new IllegalArgumentException("이미 중복된 사용자가 존재합니다.");
+            throw new CustomException(ErrorEnum.DUPLICATE_USER);
         }
 
         // 사용자 권한 확인
         Role role = Role.USER;
         if (requestDto.isManager()) {
             if (!MANAGER_TOKEN.equals(requestDto.getManagerToken())) {
-                throw new IllegalArgumentException("잘못된 암호입니다.");
+                throw new CustomException(ErrorEnum.BAD_MANAGER_TOKEN);
             }
             role = Role.MANAGER;
         }
@@ -60,19 +68,26 @@ public class AuthService {
         return new SignupResponseDto(user);
     }
 
-    // 로그인
+    /**
+     * 로그인
+     *
+     * @param requestDto 로그인 요청 데이터
+     * @return 발급된 토큰 응답 데이터
+     */
     @Transactional
-    public LoginResponseDto login(LoginRequestDto requestDto) {
+    public TokenResponseDto login(LoginRequestDto requestDto) {
         User user = userRepository.findByUsername(requestDto.getUsername()).orElseThrow(
-                () -> new IllegalArgumentException("아이디를 다시 확인해주세요.")
+                () -> new CustomException(ErrorEnum.USER_NOT_FOUND)
         );
 
-        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+        // 회원 상태 확인
+        if (!user.isExist()) {
+            throw new CustomException(ErrorEnum.WITHDRAW_USER);
         }
 
-        if (!user.isExist()) {
-            throw new IllegalArgumentException("탈퇴한 사용자입니다.");
+        // 암호화 비밀번호 검증
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorEnum.INCORRECT_PASSWORD);
         }
 
         String accessToken = jwtUtil.createAccessToken(requestDto.getUsername(), user.getRole());
@@ -80,37 +95,43 @@ public class AuthService {
 
         user.updateRefresh(refreshToken);
 
-        return new LoginResponseDto(accessToken, refreshToken);
+        return new TokenResponseDto(accessToken, refreshToken);
     }
 
-    // 로그아웃
+    /**
+     * 로그아웃
+     *
+     * @param user 유저 정보
+     */
     @Transactional
     public void logout(User user) {
         User finduser = userRepository.findByUsername(user.getUsername()).orElseThrow(
-                () -> new IllegalArgumentException("아이디를 다시 확인해주세요.")
+                () -> new CustomException(ErrorEnum.USER_NOT_FOUND)
         );
 
+        // 회원 상태 확인
         if (!user.isExist()) {
-            throw new IllegalArgumentException("탈퇴한 사용자입니다.");
+            throw new CustomException(ErrorEnum.WITHDRAW_USER);
         }
 
-        // 이미 로그아웃 상태인지 확인
-        if (finduser.getRefreshToken() == null || finduser.getRefreshToken().isEmpty()) {
-            throw new IllegalArgumentException("이미 로그아웃 상태입니다.");
-        }
-
+        // DB refresh 토큰 삭제
         finduser.updateRefresh("");
     }
 
-    // 회원탈퇴
+    /**
+     * 회원탈퇴
+     *
+     * @param user 유저 정보
+     */
     @Transactional
     public void withdraw(User user) {
         User finduser = userRepository.findByUsername(user.getUsername()).orElseThrow(
-                () -> new IllegalArgumentException("아이디를 다시 확인해주세요.")
+                () -> new CustomException(ErrorEnum.USER_NOT_FOUND)
         );
 
+        // 회원 상태 확인
         if (!user.isExist()) {
-            throw new IllegalArgumentException("탈퇴한 사용자입니다.");
+            throw new CustomException(ErrorEnum.WITHDRAW_USER);
         }
 
         finduser.updateRefresh("");

--- a/src/main/java/com/sparta/trello/common/exception/ErrorEnum.java
+++ b/src/main/java/com/sparta/trello/common/exception/ErrorEnum.java
@@ -35,6 +35,7 @@ public enum ErrorEnum {
     WITHDRAW_USER(BAD_REQUEST, "탈퇴한 회원입니다."),
     BANNED_USER(FORBIDDEN, "BAN 처리된 사용자입니다."),
     BAD_MANAGER_TOKEN(BAD_REQUEST, "잘못된 암호입니다."),
+    HEADER_NOT_FOUND_REFRESH(BAD_REQUEST,"헤더에 토큰이 존재하지 않습니다."),
 
     // Post
     POST_NOT_FOUND(BAD_REQUEST, "등록되지 않은 게시글입니다."),

--- a/src/main/java/com/sparta/trello/common/exception/ErrorEnum.java
+++ b/src/main/java/com/sparta/trello/common/exception/ErrorEnum.java
@@ -16,8 +16,14 @@ public enum ErrorEnum {
     // 필요한 에러들 만드시고 사용하시면 됩니다.
 
     // Token
-    INVALID_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
-    TOKEN_EXPIRATION(BAD_REQUEST, "만료된 토큰입니다"),
+    INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 JWT 서명입니다."),
+    TOKEN_EXPIRATION(UNAUTHORIZED, "만료된 토큰입니다. 재로그인 해주세요."),
+    NOT_SUPPORTED_TOKEN(UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
+    FALSE_TOKEN(BAD_REQUEST, "잘못된 JWT 토큰입니다."),
+    HEADER_NOT_FOUND_AUTH(BAD_REQUEST, "권한 헤더가 잘못되었거나 누락되었습니다."),
+    TOKEN_VALIDATE(BAD_REQUEST, "Invalid JWT token."),
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
+    UNMATCHED_TOKEN(BAD_REQUEST, "일치하지 않는 토큰입니다."),
 
     // User
     INVALID_USERNAME(BAD_REQUEST,"아이디는 최소 4자 이상, 10자 이하이며 알파벳 소문자(a~z), 숫자(0~9)로 구성되어야 합니다."),
@@ -28,6 +34,7 @@ public enum ErrorEnum {
     DUPLICATE_USER(BAD_REQUEST,"이미 등록된 사용자 입니다."),
     WITHDRAW_USER(BAD_REQUEST, "탈퇴한 회원입니다."),
     BANNED_USER(FORBIDDEN, "BAN 처리된 사용자입니다."),
+    BAD_MANAGER_TOKEN(BAD_REQUEST, "잘못된 암호입니다."),
 
     // Post
     POST_NOT_FOUND(BAD_REQUEST, "등록되지 않은 게시글입니다."),

--- a/src/main/java/com/sparta/trello/common/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/trello/common/jwt/JwtUtil.java
@@ -1,13 +1,14 @@
 package com.sparta.trello.common.jwt;
 
 import com.sparta.trello.auth.entity.Role;
+import com.sparta.trello.common.exception.CustomException;
+import com.sparta.trello.common.exception.ErrorEnum;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -80,13 +81,13 @@ public class JwtUtil {
             Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
             return true;
         } catch (SecurityException | MalformedJwtException | SignatureException e) {
-            throw new IllegalArgumentException("유효하지 않은 JWT 서명입니다.");
+            throw new CustomException(ErrorEnum.INVALID_TOKEN);
         } catch (UnsupportedJwtException e) {
-            throw new IllegalArgumentException("지원되지 않는 JWT 토큰입니다.");
+            throw new CustomException(ErrorEnum.NOT_SUPPORTED_TOKEN);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("잘못된 JWT 토큰입니다.");
+            throw new CustomException(ErrorEnum.FALSE_TOKEN);
         } catch (ExpiredJwtException e) {
-            throw new AccessDeniedException("재로그인 해주세요");
+            throw new CustomException(ErrorEnum.TOKEN_EXPIRATION);
         }
     }
 
@@ -101,7 +102,7 @@ public class JwtUtil {
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return substringToken(bearerToken);
         }
-        throw new IllegalArgumentException("Invalid or missing Authorization header");
+        throw new CustomException(ErrorEnum.HEADER_NOT_FOUND_AUTH);
     }
 
     public String getTokenFromRequest(HttpServletRequest req) {

--- a/src/main/java/com/sparta/trello/common/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/trello/common/jwt/JwtUtil.java
@@ -142,7 +142,11 @@ public class JwtUtil {
 
     public String getRefreshJwtFromHeader(HttpServletRequest request) {
         String refreshToken = request.getHeader(REFRESH_TOKEN_HEADER);
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new CustomException(ErrorEnum.HEADER_NOT_FOUND_REFRESH);
+        }
         return substringToken(refreshToken);
     }
+
 
 }


### PR DESCRIPTION
## 📌 What is this PR ?

예외처리 공통설정 및 주석, 컨벤션 수정

<br/>

## 🔎Changes
중간 피드백 - 주석 상세내용 수정
예외처리 공통 Dto 를 통해 반환 데이터 수정 (Enum 활용)
RequestDto Validation 누락 부분 추가 및 수정
LoginResponseDto => TokenResponseDto 로 이름 변경 (용도에 맞게)

+ 추가 기능
Access Token 이 만료되었을 때, Refresh Token 을 사용하여 토큰 재발급

<br/>

## 📷 Screenshot

| 기능 | 스크린샷 |
| --- | --- |
| 토큰 재발급 | ![image](https://github.com/user-attachments/assets/49ca7050-d881-43bc-822a-5b41cdac8ab0) |
| Validation | ![image](https://github.com/user-attachments/assets/cee7b976-260d-4fc7-8c10-656afef5a4c2) |

<br/>
